### PR TITLE
feat(core): enable auth hook with io.use

### DIFF
--- a/docs/content/1.getting-started/5.authentication.md
+++ b/docs/content/1.getting-started/5.authentication.md
@@ -5,7 +5,7 @@ navigation:
   icon: i-lucide-lock
 ---
 
-Nuxt Realtime exposes the Socket.IO `Server` instance through the `nuxt-realtime:io` Nitro hook before any connections are accepted. Register `io.use()` middleware there to authenticate or authorise clients.
+Nuxt Realtime exposes the Socket.IO `Server` instance through the `nuxt-realtime:io` Nitro hook before any connections are accepted. Register `io.use()` middleware there to authenticate or authorize clients.
 
 ## How it works
 

--- a/docs/content/1.getting-started/5.authentication.md
+++ b/docs/content/1.getting-started/5.authentication.md
@@ -1,0 +1,111 @@
+---
+title: Authentication
+description: Authenticate and authorize Socket.IO clients using the nuxt-realtime:io hook.
+navigation:
+  icon: i-lucide-lock
+---
+
+Nuxt Realtime exposes the Socket.IO `Server` instance through the `nuxt-realtime:io` Nitro hook before any connections are accepted. Register `io.use()` middleware there to authenticate or authorise clients.
+
+## How it works
+
+Create a Nitro server plugin and hook into `nuxt-realtime:io`. The hook fires after the `Server` is configured but before it is bound to the transport and before `connection` handlers are wired up, so every `io.use()` middleware registered here runs for every incoming connection.
+
+```ts [server/plugins/realtime-auth.ts]
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('nuxt-realtime:io', (io) => {
+    io.use((socket, next) => {
+      // authenticate here — call next() to allow, next(new Error(...)) to reject
+      next()
+    })
+  })
+})
+```
+
+## JWT-based authentication
+
+Clients pass a token via `socket.handshake.auth`:
+
+```ts [client]
+const socket = io({ auth: { token: 'your-jwt-here' } })
+```
+
+Verify it on the server:
+
+```ts [server/plugins/realtime-auth.ts]
+import jwt from 'jsonwebtoken'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('nuxt-realtime:io', (io) => {
+    io.use((socket, next) => {
+      const token = socket.handshake.auth?.token
+      if (!token) return next(new Error('Unauthorized'))
+
+      try {
+        const payload = jwt.verify(token, process.env.JWT_SECRET!)
+        socket.data.user = payload
+        next()
+      }
+      catch {
+        next(new Error('Unauthorized'))
+      }
+    })
+  })
+})
+```
+
+The middleware rejects unauthenticated connections before a `connection` event is ever emitted.
+
+## Session / cookie-based authentication
+
+Read the session cookie from the underlying HTTP request exposed via `socket.request`:
+
+```ts [server/plugins/realtime-auth.ts]
+import { parse } from 'cookie'
+import { unsealData } from 'iron-session'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('nuxt-realtime:io', (io) => {
+    io.use(async (socket, next) => {
+      const cookies = parse(socket.request.headers.cookie ?? '')
+      const sessionCookie = cookies['session']
+
+      if (!sessionCookie) return next(new Error('Unauthorized'))
+
+      try {
+        const session = await unsealData(sessionCookie, { password: process.env.SESSION_SECRET! })
+        socket.data.user = session.user
+        next()
+      }
+      catch {
+        next(new Error('Unauthorized'))
+      }
+    })
+  })
+})
+```
+
+## Gating channels with `socket.data`
+
+Once authentication sets `socket.data.user`, use that in your own event handlers to guard channel access:
+
+```ts [server/plugins/realtime-channel-guard.ts]
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('nuxt-realtime:io', (io) => {
+    io.on('connection', (socket) => {
+      socket.on('event:subscribe', (channel: string) => {
+        const user = socket.data.user
+        if (!canAccessChannel(user, channel)) {
+          socket.emit('error', { message: 'Forbidden' })
+          return
+        }
+        socket.join(`event:${channel}`)
+      })
+    })
+  })
+})
+```
+
+::callout{icon="i-lucide-info" color="info"}
+`socket.data` is typed as `any` by default. You can narrow it by extending Socket.IO's `SocketData` interface in a type definition file in your project.
+::

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,33 @@
 import { defineNuxtModule, addPlugin, createResolver, addServerPlugin, addImportsDir, logger } from '@nuxt/kit'
 import type { StorageMounts } from 'nitropack'
 import type { ServerOptions } from 'engine.io'
+import type { Server } from 'socket.io'
 import type { ReactiveRedisDriverOptions } from './drivers/redis'
+
+declare module 'nitropack' {
+  interface NitroRuntimeHooks {
+    /**
+     * Called with the Socket.IO `Server` instance before it is bound to the
+     * transport engine and before any `connection` handlers are registered.
+     * Register `io.use()` middleware here to authenticate/authorise clients.
+     *
+     * @example
+     * ```ts
+     * // server/plugins/realtime-auth.ts
+     * export default defineNitroPlugin((nitroApp) => {
+     *   nitroApp.hooks.hook('nuxt-realtime:io', (io) => {
+     *     io.use((socket, next) => {
+     *       const token = socket.handshake.auth.token
+     *       if (!verifyToken(token)) return next(new Error('Unauthorized'))
+     *       next()
+     *     })
+     *   })
+     * })
+     * ```
+     */
+    'nuxt-realtime:io': (io: Server) => void | Promise<void>
+  }
+}
 
 declare module '@nuxt/schema' {
   interface PublicRuntimeConfig {

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,7 @@ declare module 'nitropack' {
     /**
      * Called with the Socket.IO `Server` instance before it is bound to the
      * transport engine and before any `connection` handlers are registered.
-     * Register `io.use()` middleware here to authenticate/authorise clients.
+     * Register `io.use()` middleware here to authenticate/authorize clients.
      *
      * @example
      * ```ts

--- a/src/runtime/server/plugins/socketio.test.ts
+++ b/src/runtime/server/plugins/socketio.test.ts
@@ -69,7 +69,7 @@ describe('serverOptions passthrough', () => {
   it('passes nuxtRealtime.socketio.serverOptions to the Engine constructor', async () => {
     const { default: pluginFactory } = await import('./socketio')
     const nitroApp = {
-      hooks: { hook: vi.fn() },
+      hooks: { hook: vi.fn(), callHook: vi.fn().mockResolvedValue(undefined) },
       router: { use: vi.fn() },
     }
     await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
@@ -77,6 +77,139 @@ describe('serverOptions passthrough', () => {
     expect(EngineMock).toHaveBeenCalledWith(
       expect.objectContaining(serverOptions),
     )
+  })
+})
+
+describe('nuxt-realtime:io hook', () => {
+  let EngineMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetModules()
+
+    EngineMock = vi.fn()
+
+    vi.doMock('engine.io', () => ({ Server: EngineMock }))
+
+    vi.doMock('h3', () => ({
+      defineEventHandler: vi.fn().mockReturnValue({}),
+    }))
+
+    vi.doMock('../utils/logger', () => ({
+      createRealtimeLogger: vi.fn().mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('nitropack/runtime', () => ({
+      defineNitroPlugin: (factory: (app: unknown) => unknown) => factory,
+      useRuntimeConfig: () => ({
+        public: {
+          nuxtRealtime: {
+            cleanup: false,
+            logging: { level: null, format: 'text' },
+          },
+        },
+        nuxtRealtime: {},
+      }),
+      useStorage: () => ({
+        watch: vi.fn().mockResolvedValue(vi.fn()),
+        setItem: vi.fn(),
+        getItem: vi.fn(),
+        getKeys: vi.fn().mockResolvedValue([]),
+        removeItem: vi.fn(),
+      }),
+    }))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('calls the nuxt-realtime:io hook with the io instance before io.bind()', async () => {
+    const order: string[] = []
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn(() => order.push('bind'))
+      IoServer.prototype.on = vi.fn()
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      return { Server: IoServer }
+    })
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: {
+        hook: vi.fn(),
+        callHook: vi.fn().mockImplementation(async (name: string) => {
+          if (name === 'nuxt-realtime:io') order.push('hook')
+        }),
+      },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+
+    expect(order.indexOf('hook')).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf('bind')).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf('hook')).toBeLessThan(order.indexOf('bind'))
+  })
+
+  it('passes the io instance to the hook callback', async () => {
+    let capturedIo: unknown
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn()
+      IoServer.prototype.on = vi.fn()
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      return { Server: IoServer }
+    })
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: {
+        hook: vi.fn(),
+        callHook: vi.fn().mockImplementation(async (_name: string, io: unknown) => {
+          capturedIo = io
+        }),
+      },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+
+    expect(capturedIo).toBeDefined()
+  })
+})
+
+describe('nuxt-realtime:io hook — middleware runs before connection', () => {
+  it('middleware registered via io.use() executes before the connection handler', async () => {
+    const httpServer = createServer()
+    const io = new Server(httpServer)
+
+    // Simulate what a consumer does in their hook callback
+    io.use((socket, next) => {
+      socket.data.fromMiddleware = true
+      next()
+    })
+
+    let middlewareRanBeforeConnection = false
+    io.on('connection', (socket) => {
+      middlewareRanBeforeConnection = socket.data.fromMiddleware === true
+    })
+
+    const port = await new Promise<number>(resolve =>
+      httpServer.listen(0, () => resolve((httpServer.address() as AddressInfo).port)),
+    )
+
+    const client = await connectClient(port)
+    await wait(50)
+
+    expect(middlewareRanBeforeConnection).toBe(true)
+
+    client.close()
+    io.close()
+    await new Promise<void>(resolve => httpServer.close(() => resolve()))
   })
 })
 

--- a/src/runtime/server/plugins/socketio.test.ts
+++ b/src/runtime/server/plugins/socketio.test.ts
@@ -204,11 +204,14 @@ describe('nuxt-realtime:io hook — middleware runs before connection', () => {
     )
 
     const client = await connectClient(port)
-    await expect(middlewareRanBeforeConnection).resolves.toBe(true)
-
-    client.close()
-    io.close()
-    await new Promise<void>(resolve => httpServer.close(() => resolve()))
+    try {
+      await expect(middlewareRanBeforeConnection).resolves.toBe(true)
+    }
+    finally {
+      client.close()
+      io.close()
+      await new Promise<void>(resolve => httpServer.close(() => resolve()))
+    }
   })
 })
 

--- a/src/runtime/server/plugins/socketio.test.ts
+++ b/src/runtime/server/plugins/socketio.test.ts
@@ -193,9 +193,10 @@ describe('nuxt-realtime:io hook — middleware runs before connection', () => {
       next()
     })
 
-    let middlewareRanBeforeConnection = false
-    io.on('connection', (socket) => {
-      middlewareRanBeforeConnection = socket.data.fromMiddleware === true
+    const middlewareRanBeforeConnection = new Promise<boolean>((resolve) => {
+      io.on('connection', (socket) => {
+        resolve(socket.data.fromMiddleware === true)
+      })
     })
 
     const port = await new Promise<number>(resolve =>
@@ -203,9 +204,7 @@ describe('nuxt-realtime:io hook — middleware runs before connection', () => {
     )
 
     const client = await connectClient(port)
-    await wait(50)
-
-    expect(middlewareRanBeforeConnection).toBe(true)
+    await expect(middlewareRanBeforeConnection).resolves.toBe(true)
 
     client.close()
     io.close()

--- a/src/runtime/server/plugins/socketio.ts
+++ b/src/runtime/server/plugins/socketio.ts
@@ -164,6 +164,8 @@ export default defineNitroPlugin(async (nitroApp) => {
     await pubsub?.dispose()
   })
 
+  await nitroApp.hooks.callHook('nuxt-realtime:io', io)
+
   io.bind(engine)
 
   io.on('connection', (socket) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side registration point for Socket.IO middleware so authentication/authorization runs before connections are established.

* **Documentation**
  * New Authentication guide with JWT and session/cookie examples, patterns for gating channel access, and guidance to validate and narrow socket data before use.

* **Tests**
  * Added integration tests confirming the middleware hook runs before binding and that middleware-modified socket data is available in connection handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->