### PR TITLE
[codex] relay remove storage events

### DIFF
--- a/docs/content/3.technical/1.architecture.md
+++ b/docs/content/3.technical/1.architecture.md
@@ -107,5 +107,5 @@ What happens when a client calls `useRealtimeState('counter', 0)` and updates th
 2. The message travels over the WebSocket to Nitro
 3. crossws passes it to the bridge, which hands it to Engine.IO
 4. Engine.IO passes it up to Socket.IO
-5. The `storage:set` handler stores the value via Nitro's storage and broadcasts `storage:updated` to the `key:counter` room
-6. Other clients in that room receive the update and their local state refreshes
+5. The `storage:set` handler stores the value via Nitro's storage and broadcasts `storage:updated` to the `key:counter` room. If a key is removed elsewhere in the server, the watch callback emits `storage:updated` with `value: null` to the same room.
+6. Other clients in that room receive the update, reset on removal, and their local state refreshes

--- a/docs/content/3.technical/3.cross-server-sync.md
+++ b/docs/content/3.technical/3.cross-server-sync.md
@@ -50,10 +50,10 @@ sequenceDiagram
     S2->>CB: storage:updated (local room)
 ```
 
-1. Client A emits `storage:set` to Server 1, which writes to Redis and immediately emits `storage:updated` to its local room.
-2. The write also publishes a notification to `nuxt-realtime:watch`.
-3. Server 2 picks up the message, reads the new value from Redis, and broadcasts `storage:updated` to its local room.
-4. Client B receives the update.
+1. Client A emits `storage:set` or server-side code calls `storage.removeItem()`, which updates Redis and immediately emits `storage:updated` to the local room.
+2. The change also publishes a notification to `nuxt-realtime:watch`.
+3. Server 2 picks up the message, reads the current value from Redis, and broadcasts `storage:updated` to its local room. For removals, that value is `null`.
+4. Client B receives the update or reset.
 
 Server 1 won't double-broadcast to its own clients because the `origin` field on the pub/sub message matches its own `instanceId`. See [Notification Layer](/technical/pubsub#deduplication-via-instanceid) for details.
 

--- a/src/runtime/server/plugins/cross-server-sync.test.ts
+++ b/src/runtime/server/plugins/cross-server-sync.test.ts
@@ -75,7 +75,7 @@ function createServerInstance(sharedStorage: SharedStorage, instanceId: string) 
 
   // Mirrors the storage.watch() call in socketio.ts
   const unwatch = sharedStorage.watch(instanceId, (event, key) => {
-    if (event !== 'update') return
+    if (event !== 'update' && event !== 'remove') return
     if (key.startsWith('_lease:')) return
 
     const value = sharedStorage.getItem(key)
@@ -240,6 +240,25 @@ describe('cross-server sync - watch callback integration', () => {
     expect(receivedB2).toHaveLength(1)
 
     clientB2.close()
+  })
+
+  it('client on server B receives storage:updated with null when server A removes a key', async () => {
+    clientB.emit('storage:subscribe', 'counter')
+    await wait(30)
+
+    const received: unknown[] = []
+    clientB.on('storage:updated', (data) => {
+      received.push(data)
+    })
+
+    sharedStorage.setItem('counter', 42, 'instance-a')
+    await wait(30)
+    sharedStorage.removeItem('counter', 'instance-a')
+    await wait(50)
+
+    expect(received).toHaveLength(2)
+    expect(received[0]).toEqual({ key: 'counter', value: 42 })
+    expect(received[1]).toEqual({ key: 'counter', value: null })
   })
 
   it('updates to _lease: keys do not trigger storage:updated broadcasts', async () => {

--- a/src/runtime/server/plugins/socketio.ts
+++ b/src/runtime/server/plugins/socketio.ts
@@ -96,7 +96,7 @@ export default defineNitroPlugin(async (nitroApp) => {
   const STORAGE_PREFIX = 'nuxt-realtime:'
   const unwatch = await storage.watch(async (event, key) => {
     try {
-      if (event !== 'update') return
+      if (event !== 'update' && event !== 'remove') return
       if (!key.startsWith(STORAGE_PREFIX)) return
 
       const relKey = key.slice(STORAGE_PREFIX.length)


### PR DESCRIPTION
This teaches the cross-server storage watcher to relay `remove` events as `storage:updated` with `value: null`.

What changed:
- Treat `update` and `remove` as watch events worth relaying in the Nitro plugin.
- Add a regression test that simulates a key being removed on one server and verifies a subscriber on another server receives `{ key, value: null }`.
- Update the sync docs so they describe removal/reset behavior instead of only writes.

Why:
- The previous guard dropped `remove` events entirely, which left clients on other servers holding stale state after deletions.

Validation:
- Reviewed the diff and added coverage for the cross-server removal path.
- `node`/`pnpm` are not available in this environment, so I could not run Vitest here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Synchronized storage removals across servers and connected clients.
  - Clients now reset removed values to `null` instead of retaining stale state.
  - Cross-server updates correctly notify subscribed clients when data is deleted.

- **Documentation**
  - Clarified the storage removal and multi-server synchronization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->