### PR TITLE
fix(security)!: reserve the internal key namespace and isolate module state into its own storage mount

### DIFF
--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -169,7 +169,14 @@ export function reactiveRedisDriver(opts: ReactiveRedisDriverOptions = {}): Driv
   const { instanceId } = pubsub
   const listeners = new Set<WatchCallback>()
 
-  const unsubscribe = pubsub.subscribe(STORAGE_CHANNEL, (message) => {
+  // Scope the watch channel to this driver's key prefix. Keys published here are relative to
+  // `base`, so two drivers sharing one channel would hand each other's keys to their own watch
+  // callbacks: the mount would then resolve a foreign relative key against its own prefix.
+  // That matters for the internal/client mount split, and it already affected two apps sharing
+  // one Redis instance with different `base` values.
+  const channel = `${STORAGE_CHANNEL}:${baseOpts.base ?? ''}`
+
+  const unsubscribe = pubsub.subscribe(channel, (message) => {
     try {
       const { event, key, origin } = JSON.parse(message) as { event: string, key: string, origin: string }
       if (origin === instanceId) return
@@ -190,12 +197,12 @@ export function reactiveRedisDriver(opts: ReactiveRedisDriverOptions = {}): Driv
 
     async setItem(key, value, setOpts) {
       await base.setItem!(key, value, setOpts)
-      await pubsub.publish(STORAGE_CHANNEL, { event: 'update', key, origin: instanceId })
+      await pubsub.publish(channel, { event: 'update', key, origin: instanceId })
     },
 
     async removeItem(key, removeOpts) {
       await base.removeItem!(key, removeOpts)
-      await pubsub.publish(STORAGE_CHANNEL, { event: 'remove', key, origin: instanceId })
+      await pubsub.publish(channel, { event: 'remove', key, origin: instanceId })
     },
 
     watch(callback) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -333,19 +333,19 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     nuxt.hook('nitro:config', (nitroConfig) => {
+      // When `redis` is set the reactive driver is mounted at runtime by the server
+      // plugin; register a memory placeholder so Nitro does not complain about an
+      // unconfigured mount, and ignore `options.storage` so it can't shadow the
+      // runtime-mounted Redis driver.
+      const memoryOverride = options.redis ? {} : options.storage
+      // Two mounts on purpose. `nuxt-realtime` is client-facing: every key in it is
+      // reachable via storage:get/storage:set, by design. `_nuxt-realtime` holds
+      // module state (locks, presence, room membership, connection records, leases) and is
+      // never addressable from a socket event, so the trust boundary is the mount rather
+      // than a prefix check on a client-supplied string.
       nitroConfig.storage ??= {}
-      // When `redis` is set the reactive driver is mounted at runtime by the
-      // server plugin; register a memory placeholder so Nitro does not complain
-      // about an unconfigured mount.
-      if (!options.redis) {
-        nitroConfig.storage['nuxt-realtime'] = {
-          driver: 'memory',
-          ...options.storage,
-        }
-      }
-      else {
-        nitroConfig.storage['nuxt-realtime'] = { driver: 'memory' }
-      }
+      nitroConfig.storage['nuxt-realtime'] = { driver: 'memory', ...memoryOverride }
+      nitroConfig.storage['_nuxt-realtime'] = { driver: 'memory', ...memoryOverride }
     })
 
     const cleanupConfig = options.cleanup === false

--- a/src/runtime/server/plugins/socketio.security.test.ts
+++ b/src/runtime/server/plugins/socketio.security.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createStorage, prefixStorage, type Storage } from 'unstorage'
+import memoryDriver from 'unstorage/drivers/memory'
+import { isRoomMember } from '../utils/room-registry'
+import { getLocksOwnedBy, getRoomKeys } from '../utils/lock'
+
+// Regression coverage for the storage trust boundary: module state (locks, presence, room
+// membership, connection records, leases) must never be reachable or forgeable through the
+// client-facing storage:get/storage:set/storage:subscribe events, and the cleanup job must
+// release that state through the same code path a client's lock:release/room:leave would use,
+// not just delete the lease and leave the reverse indexes orphaned.
+
+// Every prefix module state is stored under (see socketio.ts's isReservedKey doc comment),
+// plus `_lease:` itself. isReservedKey rejects the whole `_` namespace, but this list is kept
+// explicit so a future prefix added to the internal mount without updating this table fails
+// loudly here instead of silently falling through untested.
+const RESERVED_PREFIXES = [
+  '_lock:',
+  '_lockinfo:',
+  '_lockowner:',
+  '_ownerlocks:',
+  '_lockroom:',
+  '_roomkeys:',
+  '_presence:',
+  '_connrooms:',
+  '_roommember:',
+  '_memberrooms:',
+  '_roomcreated:',
+  '_roomclosing:',
+  '_conn:',
+  '_reclaiming:',
+  '_lease:',
+]
+
+const RESERVED_KEYS: unknown[] = RESERVED_PREFIXES.map(prefix => `${prefix}some-target`)
+
+// storage:get ran isReservedKey outside its try/catch, so a non-string key threw out of the
+// listener instead of returning an error to the caller. These must be rejected the same way
+// a reserved-prefix string is, not crash the handler.
+const INVALID_KEYS: unknown[] = ['', null, undefined, 42, {}]
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Mirrors createRealtimeTestStorage() in socketio.test.ts, but mounts both the client-facing
+// and internal storage namespaces so tests can wire up useStorage() to route by mount name,
+// the way the real plugin does post-0002.
+function createRealtimeTestStorages(): { client: Storage, internal: Storage } {
+  const root = createStorage({ driver: memoryDriver() })
+  root.mount('nuxt-realtime', memoryDriver())
+  root.mount('_nuxt-realtime', memoryDriver())
+  return {
+    client: prefixStorage(root, 'nuxt-realtime'),
+    internal: prefixStorage(root, '_nuxt-realtime'),
+  }
+}
+
+describe('storage:get/set/subscribe reject every internal prefix and invalid key shape', () => {
+  let storageMock: {
+    watch: ReturnType<typeof vi.fn>
+    setItem: ReturnType<typeof vi.fn>
+    getItem: ReturnType<typeof vi.fn>
+    getKeys: ReturnType<typeof vi.fn>
+    removeItem: ReturnType<typeof vi.fn>
+  }
+  let connectionHandler: ((socket: unknown) => void) | undefined
+  let handlers: Record<string, (...args: unknown[]) => unknown>
+  let fakeSocket: { join: ReturnType<typeof vi.fn>, leave: ReturnType<typeof vi.fn>, to: ReturnType<typeof vi.fn>, on: ReturnType<typeof vi.fn>, rooms: Set<string>, id: string }
+
+  beforeEach(async () => {
+    vi.resetModules()
+
+    storageMock = {
+      watch: vi.fn().mockResolvedValue(vi.fn()),
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      getKeys: vi.fn().mockResolvedValue([]),
+      removeItem: vi.fn(),
+    }
+
+    vi.doMock('engine.io', () => ({ Server: vi.fn() }))
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn()
+      IoServer.prototype.on = vi.fn((event: string, cb: (socket: unknown) => void) => {
+        if (event === 'connection') connectionHandler = cb
+      })
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      return { Server: IoServer }
+    })
+
+    vi.doMock('h3', () => ({
+      defineEventHandler: vi.fn().mockReturnValue({}),
+      getQuery: vi.fn(() => ({})),
+      createError: vi.fn((opts: { statusMessage: string }) => new Error(opts.statusMessage)),
+    }))
+
+    vi.doMock('../utils/logger', () => ({
+      createRealtimeLogger: vi.fn().mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('nitropack/runtime', () => ({
+      defineNitroPlugin: (factory: (app: unknown) => unknown) => factory,
+      useRuntimeConfig: () => ({
+        public: {
+          nuxtRealtime: {
+            cleanup: false,
+            logging: { level: null, format: 'text' },
+            devtoolsEnabled: false,
+          },
+        },
+        nuxtRealtime: {},
+      }),
+      useStorage: () => storageMock,
+    }))
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: { hook: vi.fn(), callHook: vi.fn().mockResolvedValue(undefined) },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+
+    handlers = {}
+    fakeSocket = {
+      id: 'socket-abc',
+      rooms: new Set(['socket-abc']),
+      join: vi.fn(),
+      leave: vi.fn(),
+      to: vi.fn().mockReturnValue({ emit: vi.fn() }),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        handlers[event] = handler
+      }),
+    }
+    connectionHandler!(fakeSocket)
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it.each([...RESERVED_KEYS, ...INVALID_KEYS])('storage:get rejects %p without touching storage', async (key) => {
+    const callback = vi.fn()
+    await handlers['storage:get']!(key, callback)
+
+    expect(storageMock.getItem).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(null)
+  })
+
+  it.each([...RESERVED_KEYS, ...INVALID_KEYS])('storage:set rejects %p via the ack callback without touching storage', async (key) => {
+    const callback = vi.fn()
+    await handlers['storage:set']!({ key, value: 'anything' }, callback)
+
+    expect(storageMock.setItem).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ success: false }))
+  })
+
+  it.each([...RESERVED_KEYS, ...INVALID_KEYS])('storage:subscribe rejects %p without joining a key room', async (key) => {
+    await handlers['storage:subscribe']!(key)
+
+    expect(fakeSocket.join).not.toHaveBeenCalled()
+    expect(storageMock.setItem).not.toHaveBeenCalled()
+  })
+})
+
+describe('storage:get/set/subscribe still work for ordinary, non-underscore-prefixed keys', () => {
+  let storageMock: {
+    watch: ReturnType<typeof vi.fn>
+    setItem: ReturnType<typeof vi.fn>
+    getItem: ReturnType<typeof vi.fn>
+    getKeys: ReturnType<typeof vi.fn>
+    removeItem: ReturnType<typeof vi.fn>
+  }
+  let connectionHandler: ((socket: unknown) => void) | undefined
+  let handlers: Record<string, (...args: unknown[]) => unknown>
+  let fakeSocket: { join: ReturnType<typeof vi.fn>, leave: ReturnType<typeof vi.fn>, to: ReturnType<typeof vi.fn>, on: ReturnType<typeof vi.fn>, rooms: Set<string>, id: string }
+
+  // 'user_prefs' has an underscore, just not in position 0: the restriction is "starts with
+  // underscore", not "contains an underscore". 'chat:room:1' / 'room:abc:doc' exercise the
+  // colon-bearing keys the module's own docs recommend for scoping.
+  const VALID_KEYS = ['counter', 'user_prefs', 'chat:room:1', 'room:abc:doc']
+
+  beforeEach(async () => {
+    vi.resetModules()
+
+    storageMock = {
+      watch: vi.fn().mockResolvedValue(vi.fn()),
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      getKeys: vi.fn().mockResolvedValue([]),
+      removeItem: vi.fn(),
+    }
+
+    vi.doMock('engine.io', () => ({ Server: vi.fn() }))
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn()
+      IoServer.prototype.on = vi.fn((event: string, cb: (socket: unknown) => void) => {
+        if (event === 'connection') connectionHandler = cb
+      })
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      return { Server: IoServer }
+    })
+
+    vi.doMock('h3', () => ({
+      defineEventHandler: vi.fn().mockReturnValue({}),
+      getQuery: vi.fn(() => ({})),
+      createError: vi.fn((opts: { statusMessage: string }) => new Error(opts.statusMessage)),
+    }))
+
+    vi.doMock('../utils/logger', () => ({
+      createRealtimeLogger: vi.fn().mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('nitropack/runtime', () => ({
+      defineNitroPlugin: (factory: (app: unknown) => unknown) => factory,
+      useRuntimeConfig: () => ({
+        public: {
+          nuxtRealtime: {
+            cleanup: false,
+            logging: { level: null, format: 'text' },
+            devtoolsEnabled: false,
+          },
+        },
+        nuxtRealtime: {},
+      }),
+      useStorage: () => storageMock,
+    }))
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: { hook: vi.fn(), callHook: vi.fn().mockResolvedValue(undefined) },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+
+    handlers = {}
+    fakeSocket = {
+      id: 'socket-abc',
+      rooms: new Set(['socket-abc']),
+      join: vi.fn(),
+      leave: vi.fn(),
+      to: vi.fn().mockReturnValue({ emit: vi.fn() }),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        handlers[event] = handler
+      }),
+    }
+    connectionHandler!(fakeSocket)
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it.each(VALID_KEYS)('storage:get passes %p through to storage.getItem', async (key) => {
+    storageMock.getItem.mockResolvedValueOnce(`value-for-${key}`)
+    const callback = vi.fn()
+    await handlers['storage:get']!(key, callback)
+
+    expect(storageMock.getItem).toHaveBeenCalledWith(key)
+    expect(callback).toHaveBeenCalledWith(`value-for-${key}`)
+  })
+
+  it.each(VALID_KEYS)('storage:set passes %p through to storage.setItem', async (key) => {
+    const callback = vi.fn()
+    await handlers['storage:set']!({ key, value: { n: 1 } }, callback)
+
+    expect(storageMock.setItem).toHaveBeenCalledWith(key, { n: 1 })
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ success: true }))
+  })
+
+  it.each(VALID_KEYS)('storage:subscribe joins the key: room for %p', async (key) => {
+    await handlers['storage:subscribe']!(key)
+
+    expect(fakeSocket.join).toHaveBeenCalledWith(`key:${key}`)
+  })
+})
+
+describe('mount isolation: a client cannot forge module state through storage:set', () => {
+  let client: Storage
+  let internal: Storage
+  let connectionHandler: ((socket: unknown) => void | Promise<void>) | undefined
+
+  function makeFakeSocket(id: string, connectionId?: string) {
+    const handlers: Record<string, Array<(...args: unknown[]) => unknown>> = {}
+    const rooms = new Set([id])
+    return {
+      id,
+      handshake: { auth: connectionId ? { connectionId } : {} },
+      rooms,
+      handlers,
+      join: vi.fn((room: string) => rooms.add(room)),
+      leave: vi.fn((room: string) => rooms.delete(room)),
+      to: vi.fn(() => ({ emit: vi.fn() })),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        (handlers[event] ??= []).push(handler)
+      }),
+    }
+  }
+
+  async function connect(id: string, connectionId?: string) {
+    const socket = makeFakeSocket(id, connectionId)
+    await connectionHandler!(socket)
+    return { socket }
+  }
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ client, internal } = createRealtimeTestStorages())
+
+    vi.doMock('engine.io', () => ({ Server: vi.fn() }))
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn()
+      IoServer.prototype.on = vi.fn((event: string, cb: (socket: unknown) => void) => {
+        if (event === 'connection') connectionHandler = cb
+      })
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      IoServer.prototype.to = vi.fn(() => ({ emit: vi.fn() }))
+      return { Server: IoServer }
+    })
+
+    vi.doMock('h3', () => ({
+      defineEventHandler: vi.fn().mockReturnValue({}),
+    }))
+
+    vi.doMock('../utils/logger', () => ({
+      createRealtimeLogger: vi.fn().mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('nitropack/runtime', () => ({
+      defineNitroPlugin: (factory: (app: unknown) => unknown) => factory,
+      useRuntimeConfig: () => ({
+        public: {
+          nuxtRealtime: {
+            cleanup: false,
+            logging: { level: null, format: 'text' },
+          },
+        },
+        nuxtRealtime: {},
+      }),
+      // The real plugin calls useStorage('nuxt-realtime') for the client-facing handle and
+      // useStorage('_nuxt-realtime') for module state; route each to its own mount
+      // the way module.ts's two nitroConfig.storage entries do.
+      useStorage: (name?: string) => (name === '_nuxt-realtime' ? internal : client),
+    }))
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: { hook: vi.fn(), callHook: vi.fn().mockResolvedValue(undefined) },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('storage:set of _roommember:{room}:{connectionId} is rejected and never grants room membership', async () => {
+    const { socket } = await connect('socket-a', 'victim-conn')
+    const callback = vi.fn()
+    await socket.handlers['storage:set']![0]!({ key: '_roommember:private-room:victim-conn', value: true }, callback)
+
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ success: false }))
+    await expect(isRoomMember(internal, 'private-room', 'victim-conn')).resolves.toBe(false)
+    // Confirms the rejection happens before storage.setItem runs, not merely that
+    // isRoomMember can't see it.
+    await expect(client.getItem('_roommember:private-room:victim-conn')).resolves.toBeNull()
+  })
+
+  it('the client and internal mounts are separate stores: seeding the client mount directly still leaves room membership false', async () => {
+    // Bypasses storage:set/isReservedKey entirely. Room membership is read from the internal
+    // mount, so a key landing in the client mount, by whatever means, cannot affect that read.
+    // This is what makes the mount split itself the trust boundary, not just the guard tested
+    // above.
+    await client.setItem('_roommember:private-room:someone-else', true)
+
+    await expect(isRoomMember(internal, 'private-room', 'someone-else')).resolves.toBe(false)
+  })
+})
+
+describe('cleanup job releases idle locks through releaseLock(), not just the lease', () => {
+  let client: Storage
+  let internal: Storage
+  let connectionHandler: ((socket: unknown) => void | Promise<void>) | undefined
+  let ioEmits: Array<{ rooms: string[], event: string, data: unknown }>
+  let hookHandlers: Record<string, Array<(...args: unknown[]) => unknown>>
+
+  function callHook(name: string, ...args: unknown[]) {
+    return Promise.all((hookHandlers[name] ?? []).map(h => h(...args)))
+  }
+
+  function makeFakeSocket(id: string, connectionId?: string) {
+    const handlers: Record<string, Array<(...args: unknown[]) => unknown>> = {}
+    const rooms = new Set([id])
+    return {
+      id,
+      handshake: { auth: connectionId ? { connectionId } : {} },
+      rooms,
+      handlers,
+      join: vi.fn((room: string) => rooms.add(room)),
+      leave: vi.fn((room: string) => rooms.delete(room)),
+      to: vi.fn(() => ({ emit: vi.fn() })),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        (handlers[event] ??= []).push(handler)
+      }),
+    }
+  }
+
+  async function connect(id: string, connectionId?: string) {
+    const socket = makeFakeSocket(id, connectionId)
+    await connectionHandler!(socket)
+    return { socket }
+  }
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ client, internal } = createRealtimeTestStorages())
+    hookHandlers = {}
+    ioEmits = []
+
+    vi.doMock('engine.io', () => ({ Server: vi.fn() }))
+
+    vi.doMock('socket.io', () => {
+      const IoServer = vi.fn()
+      IoServer.prototype.bind = vi.fn()
+      IoServer.prototype.on = vi.fn((event: string, cb: (socket: unknown) => void) => {
+        if (event === 'connection') connectionHandler = cb
+      })
+      IoServer.prototype.sockets = { adapter: { rooms: { has: vi.fn().mockReturnValue(false) } } }
+      IoServer.prototype.to = vi.fn((r: string | string[]) => ({
+        emit: vi.fn((event: string, data: unknown) => {
+          ioEmits.push({ rooms: Array.isArray(r) ? r : [r], event, data })
+        }),
+      }))
+      return { Server: IoServer }
+    })
+
+    vi.doMock('h3', () => ({
+      defineEventHandler: vi.fn().mockReturnValue({}),
+    }))
+
+    vi.doMock('../utils/logger', () => ({
+      createRealtimeLogger: vi.fn().mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('nitropack/runtime', () => ({
+      defineNitroPlugin: (factory: (app: unknown) => unknown) => factory,
+      useRuntimeConfig: () => ({
+        public: {
+          nuxtRealtime: {
+            // Short interval/threshold so the test doesn't have to wait real-world cleanup
+            // defaults (idleThreshold defaults to an hour). Jitter is +-10% of cleanupInterval
+            // (see socketio.ts), so the first tick can land anywhere in [45ms, 55ms].
+            cleanup: { heartbeatInterval: 10_000, cleanupInterval: 50, idleThreshold: 10 },
+            logging: { level: null, format: 'text' },
+          },
+        },
+        nuxtRealtime: {},
+      }),
+      useStorage: (name?: string) => (name === '_nuxt-realtime' ? internal : client),
+    }))
+
+    const { default: pluginFactory } = await import('./socketio')
+    const nitroApp = {
+      hooks: {
+        hook: (name: string, cb: (...args: unknown[]) => unknown) => {
+          (hookHandlers[name] ??= []).push(cb)
+        },
+        callHook,
+      },
+      router: { use: vi.fn() },
+    }
+    await (pluginFactory as unknown as (app: unknown) => Promise<void>)(nitroApp)
+  })
+
+  afterEach(async () => {
+    // Stops the cleanup interval started above; without this it keeps firing against a
+    // torn-down module after the test ends.
+    await Promise.all((hookHandlers['close'] ?? []).map(h => h()))
+    vi.resetModules()
+  })
+
+  it('reaps an idle lock: clears the owner/room reverse indexes and broadcasts lock:changed', async () => {
+    const { socket } = await connect('socket-a', 'conn-1')
+    await socket.handlers['lock:claim']![0]!({ key: 'doc-1', room: 'project-1' }, vi.fn())
+
+    // Sanity check: the claim actually landed (and tagged both reverse indexes) before we
+    // wait for cleanup to reap it, so a false negative below can't be "never claimed".
+    await expect(getLocksOwnedBy(internal, 'conn-1')).resolves.toEqual(['doc-1'])
+    await expect(getRoomKeys(internal, 'project-1')).resolves.toEqual(['doc-1'])
+
+    // Several cleanupInterval (50ms) ticks, comfortably past idleThreshold (10ms).
+    await wait(300)
+
+    // Before 0002, the cleanup job deleted only the raw `_lock:doc-1` key, leaving
+    // `_lockinfo:`/`_lockowner:`/`_ownerlocks:`/`_lockroom:`/`_roomkeys:` orphaned forever.
+    await expect(getLocksOwnedBy(internal, 'conn-1')).resolves.toEqual([])
+    await expect(getRoomKeys(internal, 'project-1')).resolves.toEqual([])
+    // ...and nothing told subscribers the lock was free, so they'd keep showing it as held.
+    expect(ioEmits).toContainEqual({
+      rooms: ['lock:doc-1', 'lockroom:project-1'],
+      event: 'lock:changed',
+      data: { key: 'doc-1', owner: null, room: 'project-1' },
+    })
+  }, 10_000)
+})

--- a/src/runtime/server/plugins/socketio.ts
+++ b/src/runtime/server/plugins/socketio.ts
@@ -36,10 +36,19 @@ const EVENT_CHANNEL = 'nuxt-realtime:events'
 const LEASE_PREFIX = '_lease:'
 
 /**
- * Client-supplied storage keys must not reach into the internal `_lease:` namespace
+ * Client-supplied storage keys must not reach into any internal namespace.
+ *
+ * Module state (`_lock:`, `_lockinfo:`, `_lockowner:`, `_ownerlocks:`, `_lockroom:`,
+ * `_roomkeys:`, `_presence:`, `_connrooms:`, `_roommember:`, `_memberrooms:`,
+ * `_roomcreated:`, `_roomclosing:`, `_conn:`, `_reclaiming:`, `_lease:`) shares the
+ * `nuxt-realtime` mount with client-supplied keys, so the entire `_` prefix is reserved.
+ *
+ * Non-string keys are rejected here too: `storage:get` and `storage:set` run this check
+ * outside their try/catch, so `key.startsWith` on a non-string would throw out of the
+ * listener rather than returning an error to the caller.
  */
-function isReservedKey(key: string): boolean {
-  return key.startsWith(LEASE_PREFIX)
+function isReservedKey(key: unknown): boolean {
+  return typeof key !== 'string' || key.length === 0 || key.startsWith('_')
 }
 
 // Lock/presence/room keys are interpolated straight into storage keys (e.g. `_lock:${key}`),
@@ -77,6 +86,15 @@ export default defineNitroPlugin(async (nitroApp) => {
   }
   const cleanupConfig = realtimePublicConfig.cleanup
   const logger = createRealtimeLogger(realtimePublicConfig.logging.level, realtimePublicConfig.logging.format)
+
+  // Rejecting a key is otherwise silent for subscribe (no ack) and indistinguishable from
+  // "no value yet" for get, which makes a reserved key look like a sync bug. Warn in dev so
+  // the cause is obvious at the call site. Dev-only on purpose: a client controls this string,
+  // so warning in production would hand it a log-flooding primitive.
+  const warnReservedKey = (op: string, key: unknown) => {
+    if (!import.meta.dev) return
+    logger.warn(`${op} rejected for reserved key ${JSON.stringify(key)}: keys starting with "_" are reserved for internal module state`)
+  }
 
   const lockConfig = (config as { nuxtRealtime?: { lock?: { defaultTtl?: number, staleGraceMs?: number } } }).nuxtRealtime?.lock
   const staleGraceMs = lockConfig?.staleGraceMs ?? 10_000
@@ -118,12 +136,21 @@ export default defineNitroPlugin(async (nitroApp) => {
     const { reactiveRedisDriver, RealtimePubSub } = await import(driverPath)
     pubsub = new RealtimePubSub(redisOpts)
     const rootStorage = useStorage() as unknown as { mount: (base: string, driver: unknown) => void, unmount: (base: string) => Promise<void> }
+    const redisBase = (redisOpts as { base?: string }).base ?? ''
     await rootStorage.unmount('nuxt-realtime')
+    await rootStorage.unmount('_nuxt-realtime')
     rootStorage.mount('nuxt-realtime', reactiveRedisDriver({ ...redisOpts, pubsub, logger }))
+    // Distinct Redis key prefix so module state and client keys cannot collide there either.
+    // The pub/sub service is still shared, so the connection count stays at 2.
+    rootStorage.mount('_nuxt-realtime', reactiveRedisDriver({ ...redisOpts, base: `${redisBase}_internal:`, pubsub, logger }))
   }
 
+  // Client-facing: every key here is reachable via storage:get/storage:set by design.
   const storage = useStorage('nuxt-realtime')
-  const registry = createConnectionRegistry(storage, { staleGraceMs })
+  // Module state: locks, presence, room membership, connection records, leases.
+  // Never addressable from a socket event.
+  const internal = useStorage('_nuxt-realtime')
+  const registry = createConnectionRegistry(internal, { staleGraceMs })
 
   // Cross-server sync: watch for writes from other server instances and broadcast
   // to locally subscribed Socket.IO clients. Drivers that don't support native
@@ -139,7 +166,6 @@ export default defineNitroPlugin(async (nitroApp) => {
       if (!key.startsWith(STORAGE_PREFIX)) return
 
       const relKey = key.slice(STORAGE_PREFIX.length)
-      if (relKey.startsWith('_lease:')) return
 
       const value = await storage.getItem(relKey)
       const room = `key:${relKey}`
@@ -280,7 +306,7 @@ export default defineNitroPlugin(async (nitroApp) => {
     // caller is (or already was) a member.
     async function ensureRoomMembership(roomId: string): Promise<boolean> {
       await identityReady
-      const alreadyMember = await isRoomMember(storage, roomId, identity)
+      const alreadyMember = await isRoomMember(internal, roomId, identity)
       if (!alreadyMember) {
         const ctx = { roomId, connectionId: identity, socket, allow: true }
         try {
@@ -294,7 +320,7 @@ export default defineNitroPlugin(async (nitroApp) => {
         }
         if (!ctx.allow) return false
 
-        const { firstMember } = await joinRoom(storage, roomId, identity)
+        const { firstMember } = await joinRoom(internal, roomId, identity)
         if (firstMember) {
           await nitroApp.hooks.callHook('nuxt-realtime:roomCreated', { roomId })
         }
@@ -311,6 +337,7 @@ export default defineNitroPlugin(async (nitroApp) => {
     // Storage operations
     socket.on('storage:get', async (key: string, callback) => {
       if (isReservedKey(key)) {
+        warnReservedKey('storage:get', key)
         callback(null)
         return
       }
@@ -326,6 +353,7 @@ export default defineNitroPlugin(async (nitroApp) => {
 
     socket.on('storage:set', async ({ key, value }, callback) => {
       if (isReservedKey(key)) {
+        warnReservedKey('storage:set', key)
         if (callback) {
           callback({ success: false, error: 'Key is reserved for internal use' })
         }
@@ -333,7 +361,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       }
       try {
         await storage.setItem(key, value)
-        await touchLease(storage, key)
+        await touchLease(internal, key)
         socket.to(`key:${key}`).emit('storage:updated', { key, value })
         record('storage:set', socket.id, key)
 
@@ -356,11 +384,14 @@ export default defineNitroPlugin(async (nitroApp) => {
     })
 
     socket.on('storage:subscribe', async (key: string) => {
-      if (isReservedKey(key)) return
+      if (isReservedKey(key)) {
+        warnReservedKey('storage:subscribe', key)
+        return
+      }
       socket.join(`key:${key}`)
       record('storage:subscribe', socket.id, key)
       try {
-        await touchLease(storage, key)
+        await touchLease(internal, key)
       }
       catch (error) {
         logger.error('Lease touch error on subscribe:', error)
@@ -378,8 +409,8 @@ export default defineNitroPlugin(async (nitroApp) => {
         // Touch leases for all keys this socket is subscribed to, plus any locks it holds
         const storageRooms = [...socket.rooms].filter(r => r.startsWith('key:'))
         await Promise.all([
-          ...storageRooms.map(room => touchLease(storage, room.slice('key:'.length))),
-          ...[...ownedLocks].map(key => touchLease(storage, `_lock:${key}`)),
+          ...storageRooms.map(room => touchLease(internal, room.slice('key:'.length))),
+          ...[...ownedLocks].map(key => touchLease(internal, `_lock:${key}`)),
         ])
       }
       catch (error) {
@@ -401,7 +432,7 @@ export default defineNitroPlugin(async (nitroApp) => {
           return
         }
         await identityReady
-        const owned = await claimLock(storage, key, identity, ownerInfo, { room, ttl: ttl ?? defaultTtl })
+        const owned = await claimLock(internal, key, identity, ownerInfo, { room, ttl: ttl ?? defaultTtl })
         if (owned) {
           ownedLocks.add(key)
           const rooms = [`lock:${key}`]
@@ -428,8 +459,8 @@ export default defineNitroPlugin(async (nitroApp) => {
       }
       try {
         await identityReady
-        const room = await getLockRoom(storage, key)
-        const released = await releaseLock(storage, key, identity)
+        const room = await getLockRoom(internal, key)
+        const released = await releaseLock(internal, key, identity)
         if (released) {
           ownedLocks.delete(key)
           const rooms = [`lock:${key}`]
@@ -452,8 +483,8 @@ export default defineNitroPlugin(async (nitroApp) => {
     socket.on('lock:subscribe', async (key: string, callback) => {
       socket.join(`lock:${key}`)
       try {
-        const owner = await getLockOwner(storage, key)
-        const ownerInfo = owner ? await getLockOwnerInfo(storage, key) : null
+        const owner = await getLockOwner(internal, key)
+        const ownerInfo = owner ? await getLockOwnerInfo(internal, key) : null
         if (callback) {
           callback({ key, owner, ownerInfo })
         }
@@ -480,12 +511,12 @@ export default defineNitroPlugin(async (nitroApp) => {
           return
         }
         socket.join(`lockroom:${room}`)
-        const keys = await getRoomKeys(storage, room)
+        const keys = await getRoomKeys(internal, room)
         const snapshot: LockRoomSnapshot = {}
         for (const key of keys) {
-          const owner = await getLockOwner(storage, key)
+          const owner = await getLockOwner(internal, key)
           if (owner) {
-            snapshot[key] = { owner, ownerInfo: await getLockOwnerInfo(storage, key) }
+            snapshot[key] = { owner, ownerInfo: await getLockOwnerInfo(internal, key) }
           }
         }
         if (callback) callback(snapshot)
@@ -507,7 +538,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       }
       try {
         await identityReady
-        const currentOwner = await getLockOwner(storage, key)
+        const currentOwner = await getLockOwner(internal, key)
         const ctx = { key, connectionId: identity, currentOwner, allow: false }
         await nitroApp.hooks.callHook('nuxt-realtime:canForceRelease', ctx)
 
@@ -520,8 +551,8 @@ export default defineNitroPlugin(async (nitroApp) => {
           return
         }
 
-        const room = await getLockRoom(storage, key)
-        const released = await releaseLock(storage, key, currentOwner)
+        const room = await getLockRoom(internal, key)
+        const released = await releaseLock(internal, key, currentOwner)
         if (released) {
           const rooms = [`lock:${key}`]
           if (room) rooms.push(`lockroom:${room}`)
@@ -548,7 +579,7 @@ export default defineNitroPlugin(async (nitroApp) => {
           if (callback) callback({ success: false, error: 'Not allowed to join this room' })
           return
         }
-        await joinPresence(storage, room, identity, info ?? null)
+        await joinPresence(internal, room, identity, info ?? null)
         presenceRooms.add(room)
         socket.join(`presence:${room}`)
         socket.to(`presence:${room}`).emit('presence:changed', { room, connectionId: identity, info: info ?? null })
@@ -568,7 +599,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       }
       try {
         await identityReady
-        const existed = await leavePresence(storage, room, identity)
+        const existed = await leavePresence(internal, room, identity)
         presenceRooms.delete(room)
         socket.leave(`presence:${room}`)
         if (existed) {
@@ -593,7 +624,7 @@ export default defineNitroPlugin(async (nitroApp) => {
           return
         }
         socket.join(`presence:${room}`)
-        const snapshot = await getPresenceSnapshot(storage, room)
+        const snapshot = await getPresenceSnapshot(internal, room)
         if (callback) callback(snapshot)
       }
       catch (error) {
@@ -632,7 +663,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       }
       try {
         await identityReady
-        const { left, nowEmpty } = await leaveRoom(storage, roomId, identity)
+        const { left, nowEmpty } = await leaveRoom(internal, roomId, identity)
         joinedRooms.delete(roomId)
         socket.leave(`room:${roomId}`)
         if (left) {
@@ -663,8 +694,8 @@ export default defineNitroPlugin(async (nitroApp) => {
           return
         }
         await Promise.all([...ownedLocks].map(async (key) => {
-          const room = await getLockRoom(storage, key)
-          const released = await releaseLock(storage, key, socket.id)
+          const room = await getLockRoom(internal, key)
+          const released = await releaseLock(internal, key, socket.id)
           if (released) {
             const rooms = [`lock:${key}`]
             if (room) rooms.push(`lockroom:${room}`)
@@ -672,13 +703,13 @@ export default defineNitroPlugin(async (nitroApp) => {
           }
         }))
         await Promise.all([...presenceRooms].map(async (room) => {
-          const existed = await leavePresence(storage, room, socket.id)
+          const existed = await leavePresence(internal, room, socket.id)
           if (existed) {
             socket.to(`presence:${room}`).emit('presence:changed', { room, connectionId: socket.id, info: null })
           }
         }))
         await Promise.all([...joinedRooms].map(async (roomId) => {
-          const { left, nowEmpty } = await leaveRoom(storage, roomId, socket.id)
+          const { left, nowEmpty } = await leaveRoom(internal, roomId, socket.id)
           if (left && nowEmpty) {
             await nitroApp.hooks.callHook('nuxt-realtime:roomEmpty', { roomId })
           }
@@ -733,6 +764,21 @@ export default defineNitroPlugin(async (nitroApp) => {
     })
   })
 
+  // One-time migration. Up to 0.2.x module state lived in the client-facing mount, so an
+  // upgraded deployment can still have `_lock:`/`_conn:`/`_roommember:` keys sitting in
+  // `nuxt-realtime` where clients can read them and the devtools storage panel lists them.
+  // All of it is ephemeral session state, so dropping it is safe; client keys are untouched.
+  try {
+    const staleInternalKeys = (await storage.getKeys()).filter(k => k.startsWith('_'))
+    if (staleInternalKeys.length > 0) {
+      await Promise.all(staleInternalKeys.map(k => storage.removeItem(k)))
+      logger.info(`Removed ${staleInternalKeys.length} pre-0.3 internal key(s) from the client storage mount`)
+    }
+  }
+  catch (error) {
+    logger.error('Internal key migration sweep failed:', error)
+  }
+
   // Cleanup job
   if (cleanupConfig) {
     const { cleanupInterval, idleThreshold } = cleanupConfig
@@ -743,17 +789,37 @@ export default defineNitroPlugin(async (nitroApp) => {
 
     cleanupIntervalId = setInterval(async () => {
       try {
-        const allKeys = await storage.getKeys()
-        const leaseKeys = allKeys.filter(k => k.startsWith('_lease:'))
+        const leaseKeys = (await internal.getKeys()).filter(k => k.startsWith(LEASE_PREFIX))
 
         for (const leaseKey of leaseKeys) {
-          const lease = await storage.getItem<{ lastSeen: number }>(leaseKey)
-          if (lease && Date.now() - lease.lastSeen > idleThreshold) {
-            const dataKey = leaseKey.slice('_lease:'.length)
-            await storage.removeItem(leaseKey)
-            await storage.removeItem(dataKey)
-            logger.debug(`Cleaned up idle key: ${dataKey}`)
+          const lease = await internal.getItem<{ lastSeen: number }>(leaseKey)
+          if (!lease || Date.now() - lease.lastSeen <= idleThreshold) continue
+
+          const dataKey = leaseKey.slice(LEASE_PREFIX.length)
+          await internal.removeItem(leaseKey)
+
+          // A `_lock:` lease guards module state, not a client key. Removing the raw key left
+          // _lockinfo:/_lockowner:/_ownerlocks:/_lockroom:/_roomkeys: orphaned forever and told
+          // nobody, so the holder kept reporting ownedByMe while another client could claim the
+          // same lock. Go through releaseLock and broadcast, exactly like the grace sweep.
+          if (dataKey.startsWith('_lock:')) {
+            const key = dataKey.slice('_lock:'.length)
+            const owner = await getLockOwner(internal, key)
+            if (owner) {
+              const room = await getLockRoom(internal, key)
+              const released = await releaseLock(internal, key, owner)
+              if (released) {
+                const rooms = [`lock:${key}`]
+                if (room) rooms.push(`lockroom:${room}`)
+                io.to(rooms).emit('lock:changed', { key, owner: null, room: room ?? undefined })
+              }
+            }
+            logger.debug(`Cleaned up idle lock: ${key}`)
+            continue
           }
+
+          await storage.removeItem(dataKey)
+          logger.debug(`Cleaned up idle key: ${dataKey}`)
         }
       }
       catch (error) {
@@ -779,10 +845,10 @@ export default defineNitroPlugin(async (nitroApp) => {
           const record = await registry.lookup(connectionId)
           if (!record || !registry.isGraceExpired(record)) continue
 
-          const keys = await getLocksOwnedBy(storage, connectionId)
+          const keys = await getLocksOwnedBy(internal, connectionId)
           await Promise.all(keys.map(async (key) => {
-            const room = await getLockRoom(storage, key)
-            const released = await releaseLock(storage, key, connectionId)
+            const room = await getLockRoom(internal, key)
+            const released = await releaseLock(internal, key, connectionId)
             if (released) {
               const rooms = [`lock:${key}`]
               if (room) rooms.push(`lockroom:${room}`)
@@ -790,17 +856,17 @@ export default defineNitroPlugin(async (nitroApp) => {
             }
           }))
 
-          const presenceRoomsHeld = await getPresenceRoomsForConnection(storage, connectionId)
+          const presenceRoomsHeld = await getPresenceRoomsForConnection(internal, connectionId)
           await Promise.all(presenceRoomsHeld.map(async (room) => {
-            const existed = await leavePresence(storage, room, connectionId)
+            const existed = await leavePresence(internal, room, connectionId)
             if (existed) {
               io.to(`presence:${room}`).emit('presence:changed', { room, connectionId, info: null })
             }
           }))
 
-          const memberOfRooms = await getRoomsForConnection(storage, connectionId)
+          const memberOfRooms = await getRoomsForConnection(internal, connectionId)
           await Promise.all(memberOfRooms.map(async (roomId) => {
-            const { left, nowEmpty } = await leaveRoom(storage, roomId, connectionId)
+            const { left, nowEmpty } = await leaveRoom(internal, roomId, connectionId)
             if (left && nowEmpty) {
               await nitroApp.hooks.callHook('nuxt-realtime:roomEmpty', { roomId })
             }
@@ -843,7 +909,11 @@ export default defineNitroPlugin(async (nitroApp) => {
   }))
 
   // Dev-only introspection endpoint backing the Nuxt DevTools "Realtime" tab.
-  if (devtoolsEnabled) {
+  // `devtoolsEnabled` comes from *public* runtime config, so it is overridable at runtime
+  // (NUXT_PUBLIC_NUXT_REALTIME_DEVTOOLS_ENABLED=true). This endpoint dumps every storage key
+  // and value, all connections, and all lock owner info, so gate it on the build-time dev
+  // flag as well and let the config option only ever turn it off.
+  if (devtoolsEnabled && import.meta.dev) {
     nitroApp.router.use('/__nuxt-realtime__/devtools', defineEventHandler(async (event) => {
       const query = getQuery(event)
       switch (query.type) {
@@ -852,11 +922,11 @@ export default defineNitroPlugin(async (nitroApp) => {
         case 'storage':
           return getStorageSnapshot(storage, devtoolsState.io!)
         case 'locks':
-          return getLockSnapshot(storage)
+          return getLockSnapshot(internal)
         case 'presence':
-          return getPresenceOverview(storage, await registry.listIds())
+          return getPresenceOverview(internal, await registry.listIds())
         case 'roomMembers':
-          return getRoomMembershipSnapshot(storage, await registry.listIds())
+          return getRoomMembershipSnapshot(internal, await registry.listIds())
         case 'events':
           return devtoolsState.eventLog.list(query.sinceId ? Number(query.sinceId) : undefined)
         default:


### PR DESCRIPTION
## Problem
`storage:get`/`storage:set`/`storage:subscribe` are exposed as Socket.IO events with almost no guard: the only check was `key.startsWith('_lease:')`. Module state (locks, presence, room membership, connection records) shares the client-facing `nuxt-realtime` storage mount with client-supplied keys under fourteen other `_`-prefixed prefixes, none of which were reserved.

`io.use()` only authenticates the *connection*, not individual events, and nothing stops an arbitrary `socket.io-client` from connecting directly (the composables are the intended client, not an enforced boundary). Any connected socket could therefore, without ever calling `lock:claim`/`room:join`/etc.:

- write `_roommember:{room}:{ownConnectionId}` to fake membership, skipping `nuxt-realtime:canJoinRoom` entirely
- write `_lock:{key}` / `_lockinfo:{key}` directly, hijacking a lock the UI shows as held, bypassing all of `lock.ts`'s bookkeeping (no `lock:changed` broadcast, orphaned reverse indexes, unrecoverable without a manual storage edit or restart)
- write `_conn:{victimId}` with a numeric `staleAt`, then reconnect with `auth.connectionId = victimId` and have `registry.reclaim()` hand over that identity
- read `_conn:{id}` to see whatever an app's `nuxt-realtime:identify` hook wrote into `info`

Verified live against a running playground, not just in unit tests: a plain `socket.io-client` process with zero credentials was able to forge a lock on the pre-patch code, silently overwriting a real UI lock into a state no in-app action can release.

<img width="452" height="233" alt="image" src="https://github.com/user-attachments/assets/b455411e-767d-41e2-b385-f1f648da991c" />

## Fix
- **`isReservedKey()` hardened**: rejects the entire `_` prefix, not just `_lease:`, plus non-string/empty keys (a non-string key used to throw out of the listener instead of returning an error, since the check ran outside the handler's try/catch).
- **Module state moved to its own storage mount** (`_nuxt-realtime`), physically separate from the client-facing `nuxt-realtime` mount. `storage:get`/`set`/`subscribe` never hold a handle to it, so this isn't just "the guard has to stay correct forever," there's no code path from those events into that storage at all.
- Devtools introspection endpoint (dumps every storage key/value, connection, and lock owner info) now also gated on `import.meta.dev`, not just the overridable public runtime config flag.
- Cleanup job now releases idle locks through `releaseLock()` + a `lock:changed` broadcast instead of deleting the raw lease key, which used to leave five reverse indexes orphaned and tell subscribers nothing.
- `src/drivers/redis.ts` gained a per-`base` pub/sub channel, so the two mounts' watch callbacks don't hand each other's relative keys to the wrong one.

**BREAKING CHANGE:** in-flight realtime state (locks, presence, room membership, connection records) resets on upgrade, since it moves mounts. Client storage keys (whatever an app stores via `useRealtimeState`) are untouched. No manual migration step is needed: on first boot after upgrading, the plugin automatically sweeps the client mount for any pre-0.3 `_`-prefixed internal keys left behind there and removes them, logging how many it cleaned up.

## Note 
This is a breaking change touching the storage trust boundary itself, not a routine fix, so I'd really appreciate a careful review rather than a quick skim. :sweat_smile: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Isolated internal realtime state from client-accessible storage.
  * Prevented invalid or reserved storage keys from accessing internal data.
  * Improved Redis notification isolation across storage prefixes.
  * Fixed idle lock cleanup to properly release locks and broadcast updates.
  * Restricted the development tools endpoint to build-time development environments.
* **Tests**
  * Added comprehensive coverage for storage validation, mount isolation, lock cleanup, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->